### PR TITLE
Allow multi-sequence BLAST against file or database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Allow `blastn` and `blastp` to run a `Vector{BioSequence}` against a file or database
 
 ## [v1.0.0] - 2018-12-11
 - Adds support to Julia 1.0

--- a/src/blast/blastcommandline.jl
+++ b/src/blast/blastcommandline.jl
@@ -117,6 +117,11 @@ function blastn(query::Vector{DNASequence}, subject::AbstractString, flags=[]; d
     end
 end
 
+function blastn(query::AbstractString, subject::Vector{DNASequence}, flags=[])
+    subjectpath = makefasta(subject)
+    return blastn(query, subjectpath, flags)
+end
+
 """
 `blastp(query, subject, flags...)``
 Runs blastn on `query` against `subject`.
@@ -164,6 +169,11 @@ function blastp(query::Vector{AminoAcidSequence}, subject::AbstractString, flags
     else
         return blastp(querypath, subject, flags)
     end
+end
+
+function blastp(query::AbstractString, subject::Vector{AminoAcidSequence}, flags=[])
+    subjectpath = makefasta(subject)
+    return blastp(query, subjectpath, flags)
 end
 
 # Create temporary fasta-formated file for blasting.

--- a/src/blast/blastcommandline.jl
+++ b/src/blast/blastcommandline.jl
@@ -108,6 +108,15 @@ function blastn(query::Vector{DNASequence}, subject::Vector{DNASequence}, flags=
     return blastn(querypath, subjectpath, flags)
 end
 
+function blastn(query::Vector{DNASequence}, subject::AbstractString, flags=[]; db::Bool=false)
+    querypath = makefasta(query)
+    if db
+        return blastn(querypath, subject, flags, db=true)
+    else
+        return blastn(querypath, subject, flags)
+    end
+end
+
 """
 `blastp(query, subject, flags...)``
 Runs blastn on `query` against `subject`.
@@ -146,6 +155,15 @@ end
 function blastp(query::Vector{AminoAcidSequence}, subject::Vector{AminoAcidSequence}, flags=[])
     querypath, subjectpath = makefasta(query), makefasta(subject)
     return blastp(querypath, subjectpath, flags)
+end
+
+function blastp(query::Vector{AminoAcidSequence}, subject::AbstractString, flags=[]; db::Bool=false)
+    querypath = makefasta(query)
+    if db
+        return blastp(querypath, subject, flags, db=true)
+    else
+        return blastp(querypath, subject, flags)
+    end
 end
 
 # Create temporary fasta-formated file for blasting.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ if !Sys.iswindows()  # temporarily disable the BLAST tests on Windows (issue: #1
     @test typeof(blastn(na1, fna)) == Array{BLASTResult, 1}
     @test typeof(blastn(fna, nucldb, db=true)) == Array{BLASTResult, 1}
     @test typeof(blastn([na1, na2], nucldb, db=true)) == Array{BLASTResult, 1}
+    @test typeof(blastn(fna, [na1, na2])) == Array{BLASTResult, 1}
 end
 
 @testset "BLAST+ blastp" begin
@@ -58,6 +59,7 @@ end
     @test typeof(blastp(aa1, faa)) == Array{BLASTResult, 1}
     @test typeof(blastp(faa, protdb, db=true)) == Array{BLASTResult, 1}
     @test typeof(blastp([aa1, aa2], protdb, db=true)) == Array{BLASTResult, 1}
+    @test typeof(blastp(faa, [aa1, aa2])) == Array{BLASTResult, 1}
 end
 
 end  # if !is_windows()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ if !Sys.iswindows()  # temporarily disable the BLAST tests on Windows (issue: #1
     @test typeof(blastn(na1, nucldb, db=true)) == Array{BLASTResult, 1}
     @test typeof(blastn(na1, fna)) == Array{BLASTResult, 1}
     @test typeof(blastn(fna, nucldb, db=true)) == Array{BLASTResult, 1}
+    @test typeof(blastn([na1, na2], nucldb, db=true)) == Array{BLASTResult, 1}
 end
 
 @testset "BLAST+ blastp" begin
@@ -56,6 +57,7 @@ end
     @test typeof(blastp(aa1, protdb, db=true)) == Array{BLASTResult, 1}
     @test typeof(blastp(aa1, faa)) == Array{BLASTResult, 1}
     @test typeof(blastp(faa, protdb, db=true)) == Array{BLASTResult, 1}
+    @test typeof(blastp([aa1, aa2], protdb, db=true)) == Array{BLASTResult, 1}
 end
 
 end  # if !is_windows()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ if !Sys.iswindows()  # temporarily disable the BLAST tests on Windows (issue: #1
     @test typeof(blastn(na1, fna)) == Array{BLASTResult, 1}
     @test typeof(blastn(fna, nucldb, db=true)) == Array{BLASTResult, 1}
     @test typeof(blastn([na1, na2], nucldb, db=true)) == Array{BLASTResult, 1}
+    @test typeof(blastn([na1, na2], fna)) == Array{BLASTResult, 1}
     @test typeof(blastn(fna, [na1, na2])) == Array{BLASTResult, 1}
 end
 
@@ -59,6 +60,7 @@ end
     @test typeof(blastp(aa1, faa)) == Array{BLASTResult, 1}
     @test typeof(blastp(faa, protdb, db=true)) == Array{BLASTResult, 1}
     @test typeof(blastp([aa1, aa2], protdb, db=true)) == Array{BLASTResult, 1}
+    @test typeof(blastp([aa1, aa2], faa)) == Array{BLASTResult, 1}
     @test typeof(blastp(faa, [aa1, aa2])) == Array{BLASTResult, 1}
 end
 


### PR DESCRIPTION
# Allow multi-sequence BLAST against file or database

## Types of changes

This PR implements the following changes:

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Currently, not all combinations of query and subject types are allowed with `blastn` and `blastp`. This PR adds support for Vector{BioSequence} vs AbstractString, to allow blasting multiple sequences against, for example, a local copy of the NCBI NR database from within Julia. I also added AbstractString vs Vector{BioSequences} for good measure. Both combinations resulted in errors previously, so this is non-breaking.

## :ballot_box_with_check: Checklist

- [ ] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
